### PR TITLE
Nameを渡せるようにする

### DIFF
--- a/cmd/vonage/main.go
+++ b/cmd/vonage/main.go
@@ -16,13 +16,14 @@ const (
 
 func main() {
 	phoneNumber := "1234567890"
-	err := CallPhoneApi(phoneNumber)
+	name := "Alisa"
+	err := CallPhoneApi(phoneNumber, name)
 	if err != nil {
 		fmt.Println("Error making API call:", err)
 	}
 }
 
-func CallPhoneApi(phoneNumber string) error {
+func CallPhoneApi(phoneNumber, name string) error {
 	XKey, err := FetchEnvVar("XKey")
 	if err != nil {
 		return err
@@ -33,7 +34,7 @@ func CallPhoneApi(phoneNumber string) error {
 		return err
 	}
 
-	requestBody, err := CreateRequestBody(AgentId, phoneNumber)
+	requestBody, err := CreateRequestBody(AgentId, phoneNumber, name)
 	if err != nil {
 		return err
 	}
@@ -61,11 +62,18 @@ func FetchEnvVar(key string) (string, error) {
 	return value, nil
 }
 
-func CreateRequestBody(agentId, phoneNumber string) ([]byte, error) {
-	requestBody, err := json.Marshal(map[string]string{
+func CreateRequestBody(agentId, phoneNumber, name string) ([]byte, error) {
+	requestBody, err := json.Marshal(map[string]interface{}{
 		"agent_id": agentId,
 		"to":       phoneNumber,
+		"session_parameters": []map[string]string{
+			{
+				"name":  "CALLER_NAME",
+				"value": name,
+			},
+		},
 	})
+
 	if err != nil {
 		fmt.Println("Error marshalling JSON:", err)
 		return nil, err


### PR DESCRIPTION
# やったこと
現在のBodyはただ、電話を呼ぶだけの設定のものになっている。
そこに"session_parameters"を取ることで、名前をAI Studio側に渡すことができる。

今回の実装では、nameの値を外部から受け取り、その値をsession_parametersに入れることで、AI Studio側にnameの値を渡せるようにする。